### PR TITLE
Correct test for glmmTMB 1.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,12 @@ estimates.
 ``` r
 mtscr_model(mtscr_creativity, id, item, SemDis_MEAN, top = 1:3) |>
   mtscr_model_summary()
-#> # A tibble: 3 × 9
-#>   model  nobs sigma logLik    AIC    BIC df.residual emp_rel   FDI
-#>   <chr> <int> <dbl>  <dbl>  <dbl>  <dbl>       <int>   <dbl> <dbl>
-#> 1 top1   4585 0.736 -5298. 10657. 10850.        4555   0.877 0.936
-#> 2 top2   4585 0.767 -5472. 11003. 11196.        4555   0.892 0.944
-#> 3 top3   4585 0.825 -5777. 11613. 11806.        4555   0.896 0.947
+#> # A tibble: 3 × 10
+#>   model  nobs sigma logLik    AIC    BIC deviance df.residual emp_rel   FDI
+#>   <chr> <int> <dbl>  <dbl>  <dbl>  <dbl>    <dbl>       <int>   <dbl> <dbl>
+#> 1 top1   4585 0.736 -5298. 10657. 10850.    2383.        4555   0.877 0.936
+#> 2 top2   4585 0.767 -5472. 11003. 11196.    2597.        4555   0.892 0.944
+#> 3 top3   4585 0.825 -5777. 11613. 11806.    3024.        4555   0.896 0.947
 ```
 
 ### Graphical User Interface

--- a/tests/testthat/test-mtscr_model_summary.R
+++ b/tests/testthat/test-mtscr_model_summary.R
@@ -2,7 +2,7 @@ test_that("model is summarised", {
   summary <- mtscr_model(mtscr_creativity, id, item, SemDis_MEAN, top = 1:3) |>
     mtscr_model_summary()
 
-  expect_equal(dim(summary), c(3, 9))
+  expect_equal(dim(summary), c(3, 10))
 })
 
 # Test that model must be a glmmTMB object or a list of glmmTMB objects


### PR DESCRIPTION
`glmmTMB` 1.1.8 adds a column to model summary thus breaking a test. This PR corrects the error closing #1.